### PR TITLE
perf: improve performance by adding `inline` and `cold` attributes, and slice access over index access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "ciborium"
@@ -76,18 +76,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -196,9 +196,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustversion"
@@ -355,18 +355,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -375,14 +385,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -408,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "walkdir"
@@ -424,21 +435,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -450,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -460,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -473,18 +485,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -492,89 +504,31 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xsum"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsum"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.69"
 license = "MIT"

--- a/benches/bench_xsum_sum.rs
+++ b/benches/bench_xsum_sum.rs
@@ -1,14 +1,16 @@
 mod common;
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use xsum::{Xsum, XsumAuto, XsumLarge, XsumSmall};
 
 use crate::common::DATA_MAP_F64;
 
-fn xsumsmall_add_list_bench(c: &mut Criterion) {
+fn xsum_sum_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("xsum");
     for (size, array) in DATA_MAP_F64.iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+
         group.bench_with_input(
             BenchmarkId::new("xsumsmall add_list", size),
             *array,
@@ -16,7 +18,7 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
                 bench.iter(|| {
                     let mut xsumsmall = XsumSmall::new();
                     xsumsmall.add_list(black_box(arr));
-                    xsumsmall.sum();
+                    black_box(xsumsmall.sum());
                 })
             },
         );
@@ -30,7 +32,7 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
                     for v in arr {
                         xsumsmall.add(black_box(*v));
                     }
-                    xsumsmall.sum();
+                    black_box(xsumsmall.sum());
                 })
             },
         );
@@ -42,7 +44,7 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
                 bench.iter(|| {
                     let mut xsumlarge = XsumLarge::new();
                     xsumlarge.add_list(black_box(arr));
-                    xsumlarge.sum();
+                    black_box(xsumlarge.sum());
                 })
             },
         );
@@ -56,7 +58,7 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
                     for v in arr {
                         xsumlarge.add(black_box(*v));
                     }
-                    xsumlarge.sum();
+                    black_box(xsumlarge.sum());
                 })
             },
         );
@@ -68,7 +70,7 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
                 bench.iter(|| {
                     let mut xsumauto = XsumAuto::new();
                     xsumauto.add_list(black_box(arr));
-                    xsumauto.sum();
+                    black_box(xsumauto.sum());
                 })
             },
         );
@@ -82,7 +84,7 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
                     for v in arr {
                         xsumauto.add(black_box(*v));
                     }
-                    xsumauto.sum();
+                    black_box(xsumauto.sum());
                 })
             },
         );
@@ -90,5 +92,5 @@ fn xsumsmall_add_list_bench(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, xsumsmall_add_list_bench);
+criterion_group!(benches, xsum_sum_bench);
 criterion_main!(benches);

--- a/src/accumulators/large_accumulator.rs
+++ b/src/accumulators/large_accumulator.rs
@@ -105,6 +105,7 @@ impl LargeAccumulator {
         self.m_used_used |= 1u64 << (ix >> 6);
     }
 
+    #[cold]
     pub(crate) fn large_add_value_inf_nan(&mut self, ix: usize, uintv: u64) {
         if (ix as i64 & XSUM_EXP_MASK) == XSUM_EXP_MASK {
             self.m_sacc.add_inf_nan(uintv as i64);

--- a/src/accumulators/small_accumulator.rs
+++ b/src/accumulators/small_accumulator.rs
@@ -151,6 +151,7 @@ impl SmallAccumulator {
         uix // Return index of uppermost non-zero chunk
     }
 
+    #[cold]
     pub(crate) fn add_inf_nan(&mut self, ivalue: i64) {
         let mantissa: i64 = ivalue & XSUM_MANTISSA_MASK;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -46,7 +46,7 @@ pub trait XsumExt {
 
 impl XsumExt for [f64] {
     fn xsum(&self) -> f64 {
-        if self.len() > XSUM_THRESHOLD {
+        if self.len() < XSUM_THRESHOLD {
             let mut xsumsmall = xsum_small::XsumSmall::new();
             xsumsmall.add_list(self);
             xsumsmall.sum()

--- a/src/xsum_auto.rs
+++ b/src/xsum_auto.rs
@@ -89,6 +89,7 @@ impl Xsum for XsumAuto {
     /// }
     /// assert_eq!(xauto.sum(), 1_000.0);
     /// ```
+    #[inline(always)]
     fn add(&mut self, value: f64) {
         match &mut self.m_xsum {
             XsumKind::XSmall(xsmal) => {

--- a/src/xsum_large.rs
+++ b/src/xsum_large.rs
@@ -47,8 +47,8 @@ impl Xsum for XsumLarge {
     /// assert_eq!(xlarge.sum(), 1_000.0);
     /// ```
     fn add_list(&mut self, vec: &[f64]) {
-        for value in vec {
-            self.add(*value);
+        for &value in vec {
+            self.add(value);
         }
     }
 
@@ -62,6 +62,7 @@ impl Xsum for XsumLarge {
     /// }
     /// assert_eq!(xlarge.sum(), 1_000.0);
     /// ```
+    #[inline(always)]
     fn add(&mut self, value: f64) {
         // increment
         self.m_lacc.m_sacc.increment_when_value_added(value);

--- a/src/xsum_small.rs
+++ b/src/xsum_small.rs
@@ -41,10 +41,12 @@ impl XsumSmall {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn get_size_count(&self) -> usize {
         self.m_sacc.m_size_count
     }
 
+    #[inline(always)]
     pub(crate) fn transfer_accumulator(self) -> SmallAccumulator {
         self.m_sacc
     }
@@ -73,8 +75,7 @@ impl Xsum for XsumSmall {
                 self.m_sacc.carry_propagate();
             }
             let m: usize = std::cmp::min(n, self.m_sacc.m_adds_until_propagate as usize);
-            for i in 0..m {
-                let value: f64 = vec[offset + i];
+            for &value in &vec[offset..offset + m] {
                 self.m_sacc.increment_when_value_added(value);
                 self.m_sacc.add1_no_carry(value);
             }
@@ -94,6 +95,7 @@ impl Xsum for XsumSmall {
     /// }
     /// assert_eq!(xsmall.sum(), 6.0);
     /// ```
+    #[inline(always)]
     fn add(&mut self, value: f64) {
         self.m_sacc.increment_when_value_added(value);
         if self.m_sacc.m_adds_until_propagate == 0 {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,15 +1,16 @@
 use xsum::{Xsum, XsumAuto, XsumExt, XsumLarge, XsumSmall};
 
 fn is_valid(actual: f64, expected: f64) -> bool {
-    if !actual.is_nan()
-        && (actual != expected || actual.is_sign_negative() != expected.is_sign_negative())
-    {
-        return false;
+    // check NaN, 0, -0, infinity, -infinity, finite values
+    if actual.to_bits() == expected.to_bits() {
+        return true;
     }
-    if !actual.is_nan() && expected.is_nan() {
-        return false;
+
+    // check NaN with no payload
+    if actual.is_nan() && expected.is_nan() {
+        return true;
     }
-    true
+    false
 }
 
 pub fn same_value(vec: &[f64], expected: f64) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -192,10 +192,14 @@ fn complex() {
 #[test]
 fn nan_infinity() {
     same_value(&[NaN], NaN);
+    same_value(&[NaN, 2.4], NaN);
+    same_value(&[INFINITY, NaN], NaN);
+    same_value(&[INFINITY, NaN, 1.5], NaN);
     same_value(&[INFINITY, -INFINITY], NaN);
     same_value(&[-INFINITY, INFINITY], NaN);
 
     same_value(&[INFINITY], INFINITY);
+    same_value(&[INFINITY, 23.3], INFINITY);
     same_value(&[INFINITY, INFINITY], INFINITY);
     same_value(&[-INFINITY], -INFINITY);
     same_value(&[-INFINITY, -INFINITY], -INFINITY);


### PR DESCRIPTION
- Improve performance by adding `inline` and `cold` attributes, and slice access over index access
- Improve benchmark code
- Improve test cases
- Update dev dependencies

### Benchmark comparison

Compared the latest main at this moment (https://github.com/Gumichocopengin8/xsum.rs/commit/3add6bec24bba69c999bb2d21d65b730457adbdd) and this PR change on Mac (`15.6.1` 16GB M1 Pro).

Overall, the benchmarks are improved or the same. `xsum/xsumauto add_list/50000`, `xsum/xsumlarge add/100`, and `xsum/xsumauto add_list/100` are regressed up to `1.7%` except `xsum/xsumlarge add/100` (`4.9%` regression). However, `xsum/xsumlarge add/100` shouldn't be used with 100 data size in practice, so it's improved overall.

```bash
$ cargo bench xsum
   Compiling xsum v0.1.2 (/xsum)
    Finished `bench` profile [optimized] target(s) in 15.88s
     Running unittests src/lib.rs (target/release/deps/xsum-ad971a16d0e9e0be)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench_xsum_sum.rs (target/release/deps/bench_xsum_sum-14151473bf60571f)
Gnuplot not found, using plotters backend
xsum/xsumsmall add_list/1000
                        time:   [2.1481 µs 2.1498 µs 2.1516 µs]
                        thrpt:  [464.78 Melem/s 465.15 Melem/s 465.54 Melem/s]
                 change:
                        time:   [+0.9358% +1.0160% +1.0989%] (p = 0.00 < 0.05)
                        thrpt:  [−1.0869% −1.0058% −0.9272%]
                        Change within noise threshold.
xsum/xsumsmall add/1000 time:   [2.2511 µs 2.2529 µs 2.2552 µs]
                        thrpt:  [443.42 Melem/s 443.87 Melem/s 444.23 Melem/s]
                 change:
                        time:   [−35.569% −35.514% −35.463%] (p = 0.00 < 0.05)
                        thrpt:  [+54.949% +55.073% +55.205%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
xsum/xsumlarge add_list/1000
                        time:   [3.3660 µs 3.3922 µs 3.4191 µs]
                        thrpt:  [292.47 Melem/s 294.80 Melem/s 297.09 Melem/s]
                 change:
                        time:   [−0.7035% +0.7879% +2.4246%] (p = 0.31 > 0.05)
                        thrpt:  [−2.3672% −0.7817% +0.7084%]
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
xsum/xsumlarge add/1000 time:   [3.4146 µs 3.4518 µs 3.4909 µs]
                        thrpt:  [286.46 Melem/s 289.70 Melem/s 292.86 Melem/s]
                 change:
                        time:   [−4.7727% −3.6108% −2.4862%] (p = 0.00 < 0.05)
                        thrpt:  [+2.5496% +3.7460% +5.0119%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) low severe
  4 (4.00%) high mild
  8 (8.00%) high severe
xsum/xsumauto add_list/1000
                        time:   [2.1507 µs 2.1526 µs 2.1550 µs]
                        thrpt:  [464.03 Melem/s 464.55 Melem/s 464.97 Melem/s]
                 change:
                        time:   [+0.9941% +1.1309% +1.2684%] (p = 0.00 < 0.05)
                        thrpt:  [−1.2525% −1.1182% −0.9843%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
xsum/xsumauto add/1000  time:   [2.3777 µs 2.3821 µs 2.3866 µs]
                        thrpt:  [419.01 Melem/s 419.79 Melem/s 420.57 Melem/s]
                 change:
                        time:   [−31.861% −31.749% −31.643%] (p = 0.00 < 0.05)
                        thrpt:  [+46.291% +46.517% +46.759%]
                        Performance has improved.
xsum/xsumsmall add_list/5000
                        time:   [10.456 µs 10.462 µs 10.470 µs]
                        thrpt:  [477.57 Melem/s 477.92 Melem/s 478.19 Melem/s]
                 change:
                        time:   [+0.4090% +0.5760% +0.7350%] (p = 0.00 < 0.05)
                        thrpt:  [−0.7297% −0.5727% −0.4074%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
xsum/xsumsmall add/5000 time:   [10.997 µs 11.004 µs 11.013 µs]
                        thrpt:  [454.01 Melem/s 454.40 Melem/s 454.67 Melem/s]
                 change:
                        time:   [−36.105% −35.994% −35.851%] (p = 0.00 < 0.05)
                        thrpt:  [+55.886% +56.235% +56.507%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
xsum/xsumlarge add_list/5000
                        time:   [11.861 µs 11.907 µs 11.949 µs]
                        thrpt:  [418.45 Melem/s 419.90 Melem/s 421.53 Melem/s]
                 change:
                        time:   [−2.1675% −1.6849% −1.1964%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2109% +1.7138% +2.2155%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
xsum/xsumlarge add/5000 time:   [12.028 µs 12.075 µs 12.122 µs]
                        thrpt:  [412.48 Melem/s 414.09 Melem/s 415.70 Melem/s]
                 change:
                        time:   [−1.4394% −1.0794% −0.7038%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7088% +1.0912% +1.4605%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
xsum/xsumauto add_list/5000
                        time:   [11.801 µs 11.845 µs 11.895 µs]
                        thrpt:  [420.35 Melem/s 422.12 Melem/s 423.70 Melem/s]
                 change:
                        time:   [−0.8175% −0.4602% −0.1389%] (p = 0.01 < 0.05)
                        thrpt:  [+0.1391% +0.4624% +0.8242%]
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe
xsum/xsumauto add/5000  time:   [12.149 µs 12.177 µs 12.207 µs]
                        thrpt:  [409.61 Melem/s 410.62 Melem/s 411.56 Melem/s]
                 change:
                        time:   [−8.3213% −8.0127% −7.7139%] (p = 0.00 < 0.05)
                        thrpt:  [+8.3587% +8.7106% +9.0766%]
                        Performance has improved.
xsum/xsumsmall add_list/20000
                        time:   [41.606 µs 41.622 µs 41.638 µs]
                        thrpt:  [480.33 Melem/s 480.51 Melem/s 480.70 Melem/s]
                 change:
                        time:   [+0.1899% +0.3364% +0.4574%] (p = 0.00 < 0.05)
                        thrpt:  [−0.4553% −0.3352% −0.1896%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
xsum/xsumsmall add/20000
                        time:   [45.224 µs 45.296 µs 45.370 µs]
                        thrpt:  [440.82 Melem/s 441.54 Melem/s 442.24 Melem/s]
                 change:
                        time:   [−34.251% −34.151% −34.044%] (p = 0.00 < 0.05)
                        thrpt:  [+51.617% +51.862% +52.095%]
                        Performance has improved.
xsum/xsumlarge add_list/20000
                        time:   [43.136 µs 43.189 µs 43.246 µs]
                        thrpt:  [462.47 Melem/s 463.08 Melem/s 463.65 Melem/s]
                 change:
                        time:   [−0.6889% −0.5748% −0.4557%] (p = 0.00 < 0.05)
                        thrpt:  [+0.4578% +0.5781% +0.6936%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
xsum/xsumlarge add/20000
                        time:   [44.031 µs 44.112 µs 44.201 µs]
                        thrpt:  [452.48 Melem/s 453.39 Melem/s 454.23 Melem/s]
                 change:
                        time:   [−0.5813% −0.4081% −0.2473%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2479% +0.4097% +0.5847%]
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
xsum/xsumauto add_list/20000
                        time:   [43.136 µs 43.180 µs 43.223 µs]
                        thrpt:  [462.72 Melem/s 463.18 Melem/s 463.65 Melem/s]
                 change:
                        time:   [+0.2128% +0.3290% +0.4533%] (p = 0.00 < 0.05)
                        thrpt:  [−0.4513% −0.3279% −0.2124%]
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low severe
  9 (9.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
xsum/xsumauto add/20000 time:   [43.963 µs 44.010 µs 44.064 µs]
                        thrpt:  [453.88 Melem/s 454.44 Melem/s 454.93 Melem/s]
                 change:
                        time:   [−3.2640% −3.1721% −3.0736%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1711% +3.2761% +3.3741%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high severe
xsum/xsumsmall add_list/100000
                        time:   [207.22 µs 207.44 µs 207.74 µs]
                        thrpt:  [481.38 Melem/s 482.06 Melem/s 482.58 Melem/s]
                 change:
                        time:   [+0.3141% +0.4291% +0.5450%] (p = 0.00 < 0.05)
                        thrpt:  [−0.5421% −0.4272% −0.3131%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
xsum/xsumsmall add/100000
                        time:   [220.18 µs 220.74 µs 221.40 µs]
                        thrpt:  [451.67 Melem/s 453.01 Melem/s 454.17 Melem/s]
                 change:
                        time:   [−35.733% −35.608% −35.487%] (p = 0.00 < 0.05)
                        thrpt:  [+55.007% +55.298% +55.601%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
xsum/xsumlarge add_list/100000
                        time:   [208.95 µs 209.18 µs 209.46 µs]
                        thrpt:  [477.41 Melem/s 478.05 Melem/s 478.59 Melem/s]
                 change:
                        time:   [−1.1115% −1.0158% −0.9200%] (p = 0.00 < 0.05)
                        thrpt:  [+0.9285% +1.0262% +1.1240%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
xsum/xsumlarge add/100000
                        time:   [212.20 µs 212.26 µs 212.32 µs]
                        thrpt:  [470.98 Melem/s 471.11 Melem/s 471.25 Melem/s]
                 change:
                        time:   [−0.2580% −0.1794% −0.0931%] (p = 0.00 < 0.05)
                        thrpt:  [+0.0932% +0.1797% +0.2587%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
xsum/xsumauto add_list/100000
                        time:   [208.57 µs 208.61 µs 208.65 µs]
                        thrpt:  [479.27 Melem/s 479.36 Melem/s 479.46 Melem/s]
                 change:
                        time:   [−0.5641% −0.2463% +0.0092%] (p = 0.10 > 0.05)
                        thrpt:  [−0.0092% +0.2469% +0.5673%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
xsum/xsumauto add/100000
                        time:   [212.44 µs 212.60 µs 212.78 µs]
                        thrpt:  [469.98 Melem/s 470.38 Melem/s 470.71 Melem/s]
                 change:
                        time:   [−1.0739% −1.0018% −0.9252%] (p = 0.00 < 0.05)
                        thrpt:  [+0.9339% +1.0120% +1.0856%]
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  6 (6.00%) high mild
  10 (10.00%) high severe
xsum/xsumsmall add_list/10000
                        time:   [20.789 µs 20.798 µs 20.808 µs]
                        thrpt:  [480.60 Melem/s 480.80 Melem/s 481.02 Melem/s]
                 change:
                        time:   [+0.2333% +0.3215% +0.3944%] (p = 0.00 < 0.05)
                        thrpt:  [−0.3928% −0.3205% −0.2328%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
xsum/xsumsmall add/10000
                        time:   [21.871 µs 21.876 µs 21.882 µs]
                        thrpt:  [457.00 Melem/s 457.12 Melem/s 457.22 Melem/s]
                 change:
                        time:   [−36.359% −36.316% −36.269%] (p = 0.00 < 0.05)
                        thrpt:  [+56.909% +57.025% +57.132%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
xsum/xsumlarge add_list/10000
                        time:   [22.256 µs 22.285 µs 22.318 µs]
                        thrpt:  [448.08 Melem/s 448.74 Melem/s 449.31 Melem/s]
                 change:
                        time:   [−0.4338% −0.3161% −0.1937%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1941% +0.3171% +0.4357%]
                        Change within noise threshold.
xsum/xsumlarge add/10000
                        time:   [22.621 µs 22.679 µs 22.744 µs]
                        thrpt:  [439.67 Melem/s 440.94 Melem/s 442.08 Melem/s]
                 change:
                        time:   [−0.8060% −0.4921% −0.2085%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2089% +0.4945% +0.8126%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe
xsum/xsumauto add_list/10000
                        time:   [22.139 µs 22.183 µs 22.225 µs]
                        thrpt:  [449.95 Melem/s 450.79 Melem/s 451.68 Melem/s]
                 change:
                        time:   [−0.0303% +0.1665% +0.3513%] (p = 0.09 > 0.05)
                        thrpt:  [−0.3501% −0.1663% +0.0303%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
xsum/xsumauto add/10000 time:   [22.826 µs 22.878 µs 22.922 µs]
                        thrpt:  [436.27 Melem/s 437.10 Melem/s 438.10 Melem/s]
                 change:
                        time:   [−4.8648% −4.6763% −4.4712%] (p = 0.00 < 0.05)
                        thrpt:  [+4.6805% +4.9057% +5.1136%]
                        Performance has improved.
xsum/xsumsmall add_list/50000
                        time:   [103.63 µs 103.75 µs 103.93 µs]
                        thrpt:  [481.09 Melem/s 481.92 Melem/s 482.49 Melem/s]
                 change:
                        time:   [−0.0564% +0.1028% +0.2458%] (p = 0.19 > 0.05)
                        thrpt:  [−0.2452% −0.1027% +0.0564%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe
xsum/xsumsmall add/50000
                        time:   [111.15 µs 111.36 µs 111.60 µs]
                        thrpt:  [448.01 Melem/s 449.00 Melem/s 449.85 Melem/s]
                 change:
                        time:   [−35.617% −35.495% −35.372%] (p = 0.00 < 0.05)
                        thrpt:  [+54.732% +55.028% +55.321%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  12 (12.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
xsum/xsumlarge add_list/50000
                        time:   [105.15 µs 105.18 µs 105.21 µs]
                        thrpt:  [475.23 Melem/s 475.37 Melem/s 475.53 Melem/s]
                 change:
                        time:   [−0.8301% −0.7486% −0.6796%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6843% +0.7542% +0.8371%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
xsum/xsumlarge add/50000
                        time:   [107.03 µs 107.18 µs 107.38 µs]
                        thrpt:  [465.62 Melem/s 466.52 Melem/s 467.14 Melem/s]
                 change:
                        time:   [−0.7241% −0.5773% −0.4315%] (p = 0.00 < 0.05)
                        thrpt:  [+0.4333% +0.5806% +0.7294%]
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
xsum/xsumauto add_list/50000
                        time:   [106.33 µs 106.72 µs 107.12 µs]
                        thrpt:  [466.78 Melem/s 468.53 Melem/s 470.24 Melem/s]
                 change:
                        time:   [+1.3924% +1.7108% +2.0061%] (p = 0.00 < 0.05)
                        thrpt:  [−1.9666% −1.6820% −1.3733%]
                        Performance has regressed.
xsum/xsumauto add/50000 time:   [107.12 µs 107.15 µs 107.18 µs]
                        thrpt:  [466.51 Melem/s 466.64 Melem/s 466.77 Melem/s]
                 change:
                        time:   [−1.4833% −1.4322% −1.3782%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3974% +1.4530% +1.5057%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
xsum/xsumsmall add_list/10
                        time:   [94.991 ns 95.157 ns 95.326 ns]
                        thrpt:  [104.90 Melem/s 105.09 Melem/s 105.27 Melem/s]
                 change:
                        time:   [−4.8487% −4.3729% −3.8866%] (p = 0.00 < 0.05)
                        thrpt:  [+4.0438% +4.5728% +5.0958%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
xsum/xsumsmall add/10   time:   [97.947 ns 98.112 ns 98.289 ns]
                        thrpt:  [101.74 Melem/s 101.92 Melem/s 102.10 Melem/s]
                 change:
                        time:   [−7.5145% −7.1245% −6.7338%] (p = 0.00 < 0.05)
                        thrpt:  [+7.2200% +7.6710% +8.1251%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
xsum/xsumlarge add_list/10
                        time:   [1.1931 µs 1.2196 µs 1.2448 µs]
                        thrpt:  [8.0335 Melem/s 8.1995 Melem/s 8.3818 Melem/s]
                 change:
                        time:   [−6.2744% −3.4061% −0.5441%] (p = 0.02 < 0.05)
                        thrpt:  [+0.5471% +3.5262% +6.6945%]
                        Change within noise threshold.
Found 21 outliers among 100 measurements (21.00%)
  10 (10.00%) low severe
  1 (1.00%) low mild
  8 (8.00%) high mild
  2 (2.00%) high severe
xsum/xsumlarge add/10   time:   [909.40 ns 947.04 ns 993.09 ns]
                        thrpt:  [10.070 Melem/s 10.559 Melem/s 10.996 Melem/s]
                 change:
                        time:   [−11.610% −7.9471% −3.9193%] (p = 0.00 < 0.05)
                        thrpt:  [+4.0792% +8.6332% +13.135%]
                        Performance has improved.
xsum/xsumauto add_list/10
                        time:   [95.757 ns 95.940 ns 96.152 ns]
                        thrpt:  [104.00 Melem/s 104.23 Melem/s 104.43 Melem/s]
                 change:
                        time:   [−6.0010% −5.4752% −4.9496%] (p = 0.00 < 0.05)
                        thrpt:  [+5.2073% +5.7923% +6.3841%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
xsum/xsumauto add/10    time:   [101.82 ns 102.00 ns 102.20 ns]
                        thrpt:  [97.849 Melem/s 98.035 Melem/s 98.210 Melem/s]
                 change:
                        time:   [−7.1830% −6.7631% −6.3315%] (p = 0.00 < 0.05)
                        thrpt:  [+6.7595% +7.2537% +7.7388%]
                        Performance has improved.
xsum/xsumsmall add_list/100
                        time:   [281.85 ns 281.93 ns 282.02 ns]
                        thrpt:  [354.59 Melem/s 354.69 Melem/s 354.80 Melem/s]
                 change:
                        time:   [+0.4853% +0.7556% +1.0379%] (p = 0.00 < 0.05)
                        thrpt:  [−1.0272% −0.7500% −0.4830%]
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) low mild
  2 (2.00%) high severe
xsum/xsumsmall add/100  time:   [299.23 ns 299.49 ns 299.74 ns]
                        thrpt:  [333.62 Melem/s 333.90 Melem/s 334.19 Melem/s]
                 change:
                        time:   [−27.413% −27.237% −27.067%] (p = 0.00 < 0.05)
                        thrpt:  [+37.112% +37.433% +37.767%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
xsum/xsumlarge add_list/100
                        time:   [1.3571 µs 1.3872 µs 1.4169 µs]
                        thrpt:  [70.577 Melem/s 72.089 Melem/s 73.687 Melem/s]
                 change:
                        time:   [−8.0720% −5.9283% −3.5576%] (p = 0.00 < 0.05)
                        thrpt:  [+3.6889% +6.3019% +8.7808%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  6 (6.00%) low severe
  6 (6.00%) low mild
  1 (1.00%) high mild
  5 (5.00%) high severe
xsum/xsumlarge add/100  time:   [1.3515 µs 1.3793 µs 1.4016 µs]
                        thrpt:  [71.348 Melem/s 72.499 Melem/s 73.990 Melem/s]
                 change:
                        time:   [+1.7004% +4.8775% +8.2403%] (p = 0.00 < 0.05)
                        thrpt:  [−7.6129% −4.6507% −1.6720%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low severe
  2 (2.00%) high mild
xsum/xsumauto add_list/100
                        time:   [284.59 ns 285.32 ns 286.09 ns]
                        thrpt:  [349.54 Melem/s 350.49 Melem/s 351.39 Melem/s]
                 change:
                        time:   [+1.0326% +1.3275% +1.6409%] (p = 0.00 < 0.05)
                        thrpt:  [−1.6144% −1.3101% −1.0221%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
xsum/xsumauto add/100   time:   [312.14 ns 312.62 ns 313.16 ns]
                        thrpt:  [319.33 Melem/s 319.88 Melem/s 320.37 Melem/s]
                 change:
                        time:   [−23.572% −23.408% −23.244%] (p = 0.00 < 0.05)
                        thrpt:  [+30.284% +30.562% +30.842%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe

     Running benches/common.rs (target/release/deps/common-1e9e9db67344768e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```