### PR TITLE
fix: release build size regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "xsum"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsum"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.69"
 license = "MIT"
@@ -20,7 +20,6 @@ mathematics = { status = "actively-developed" }
 [lints.rust]
 unsafe_code = "forbid"
 rust_2018_idioms = { level = "forbid", priority = -1 }
-missing_debug_implementations = "forbid"
 # missing_docs = "warn"
 unreachable_pub = "forbid"
 

--- a/src/accumulators/large_accumulator.rs
+++ b/src/accumulators/large_accumulator.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 
-#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) struct LargeAccumulator {
     pub(crate) m_chunk: Vec<u64>,       // Chunks making up large accumulator
     pub(crate) m_count: Vec<i32>, // Counts of # adds remaining for chunks, or -1 if not used yet or special

--- a/src/accumulators/small_accumulator.rs
+++ b/src/accumulators/small_accumulator.rs
@@ -4,7 +4,7 @@ use crate::constants::{
     XSUM_SMALL_CARRY_TERMS,
 };
 
-#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) struct SmallAccumulator {
     pub(crate) m_chunk: Vec<i64>, // Chunks making up small accumulator
     pub(crate) m_adds_until_propagate: i64, // Number of remaining adds before carry

--- a/src/xsum_auto.rs
+++ b/src/xsum_auto.rs
@@ -1,6 +1,6 @@
 use crate::{constants::XSUM_THRESHOLD, traits::Xsum, XsumLarge, XsumSmall};
 
-#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 enum XsumKind {
     XSmall(XsumSmall),
     XLarge(XsumLarge),
@@ -24,7 +24,7 @@ enum XsumKind {
 /// xauto.add_list(&vec![1.0; 1_000]);
 /// assert_eq!(xauto.sum(), 1_010.0); // use XsumLarge because input size is 1,010 in total
 /// ```
-#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct XsumAuto {
     m_xsum: XsumKind,
 }

--- a/src/xsum_large.rs
+++ b/src/xsum_large.rs
@@ -14,7 +14,7 @@ use crate::{
 /// xlarge.add_list(&vec![1.0; 1_000]);
 /// assert_eq!(xlarge.sum(), 1_000.0);
 /// ```
-#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct XsumLarge {
     m_lacc: LargeAccumulator,
 }

--- a/src/xsum_small.rs
+++ b/src/xsum_small.rs
@@ -17,7 +17,7 @@ use crate::{
 /// let vec = vec![1.0, 2.0, 3.0];
 /// assert_eq!(vec.xsum(), 6.0);
 /// ```
-#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct XsumSmall {
     m_sacc: SmallAccumulator,
 }


### PR DESCRIPTION
In https://github.com/Gumichocopengin8/xsum.rs/commit/adaf647e2713768b8511280e773f95691a84a349, `missing_debug_implementations` lint rule forced to add `#[derive(Debug)]` for each struct. 
However, this increased the release build size to `101KB` on M1 Mac. 
This patch removes the lint rule and applies `derive(Debug)` only in debug build
using `#[cfg_attr(debug_assertions, derive(Debug))]`, reducing the release build size back to `91KB`.