### PR TITLE
ci: fix GitHub Action to use the latest `rustc`, and run `cargo fmt`

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -16,7 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Update Rust version to the latest
-        run: rustup update stable
+        run: |
+          rustup self update
+          rustup update stable
+          rustup default stable
+          rustup component add clippy rustfmt
       - name: Output Rust version
         run: rustup --version
       - name: Cache
@@ -29,6 +33,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Clippy
         run: cargo clippy
+      - name: Format
+        run: cargo fmt --check
       - name: Build Debug
         run: cargo build --verbose
       - name: Run tests Debug


### PR DESCRIPTION
This patch fixes GitHub Action to use the latest `rustc`, and run `cargo fmt`
