### PR TITLE
fix: Improve doc and Add test cases 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ xsum is able to calculate fast exact summation.
 - `XsumAuto`: Automatically selects the appropriate variant when the vectors or array size is unknown.
 - `XsumVariant`: Provides a convenient interface for managing multiple Xsum structs.
 
-> [!TIP] > `XsumAuto` internally uses `XsumSmall` and `XsumLarge`.
+> [!TIP]
+>
+> `XsumAuto` internally uses `XsumSmall` and `XsumLarge`.
 > `XsumAuto` has runtime overhead to determine when to switch from `XsumSmall` to `XsumLarge`.
 > If you already know the input size in advance, consider using `XsumVariant` instead to avoid this overhead.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,21 @@
 
 This crate implments xsum algorithm by Radford M. Neal (https://arxiv.org/abs/1505.05571).
 
-xsum is able to calculate fast exact summation
+xsum is able to calculate fast exact summation.
 
-⚠️ Currently, xsum supports `f64` calculation only.
+> [!NOTE]
+> ⚠️ Currently, xsum supports `f64` calculation only.
+
+## Xsum Types
+
+- `XsumSmall`: Optimized for vectors or arrays with up to 1,000 elements.
+- `XsumLarge`: Optimized for vectors or arrays with more than 1,000 elements.
+- `XsumAuto`: Automatically selects the appropriate variant when the vectors or array size is unknown.
+- `XsumVariant`: Provides a convenient interface for managing multiple Xsum structs.
+
+> [!TIP] > `XsumAuto` internally uses `XsumSmall` and `XsumLarge`.
+> `XsumAuto` has runtime overhead to determine when to switch from `XsumSmall` to `XsumLarge`.
+> If you already know the input size in advance, consider using `XsumVariant` instead to avoid this overhead.
 
 ## Usage
 
@@ -79,6 +91,10 @@ let mut xVariant = if vec.len() < XSUM_THRESHOLD {
 xVariant.add_list(&vec);
 assert_eq!(xVariant.sum(), 2_000.0);
 ```
+
+## Comformance
+
+xsum comforms to Javascript's [Math.sumPrecise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise) behavior.
 
 ## Safety
 

--- a/src/accumulators/small_accumulator.rs
+++ b/src/accumulators/small_accumulator.rs
@@ -172,7 +172,7 @@ impl SmallAccumulator {
             // Choose the NaN with the bigger payload and clear its sign.
             // Using <= ensures that we will choose the first NaN over the previous zero.
             if (self.m_nan & XSUM_MANTISSA_MASK) <= mantissa {
-                self.m_nan = ivalue & { !XSUM_SIGN_MASK };
+                self.m_nan = ivalue & !XSUM_SIGN_MASK;
             }
         }
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,7 @@
 use crate::{constants::XSUM_THRESHOLD, xsum_large, xsum_small};
 
+/// Xsum trait
+///
 /// # Example
 ///
 /// ```

--- a/src/xsum_auto.rs
+++ b/src/xsum_auto.rs
@@ -6,7 +6,7 @@ enum XsumKind {
     XLarge(XsumLarge),
 }
 
-/// XsumAuto is efficient if vector or array size is unknown
+/// XsumAuto is efficient when vector or array size is unknown
 ///
 /// It automatically select either XsumSmall or XsumLarge based on the number of added value
 ///

--- a/src/xsum_large.rs
+++ b/src/xsum_large.rs
@@ -3,7 +3,7 @@ use crate::{
     xsum_small::XsumSmall,
 };
 
-/// XsumLarge is efficient if vector or array size is more 1,000
+/// XsumLarge is efficient when vector or array size is more than 1,000
 ///
 /// # Example
 ///

--- a/src/xsum_small.rs
+++ b/src/xsum_small.rs
@@ -7,7 +7,7 @@ use crate::{
     Xsum,
 };
 
-/// XsumSmall is efficient if vector or array size is less than or equal to 1,000
+/// XsumSmall is efficient when vector or array size is less than or equal to 1,000
 ///
 /// # Example
 ///

--- a/src/xsum_variant.rs
+++ b/src/xsum_variant.rs
@@ -70,6 +70,7 @@ impl Xsum for XsumVariant {
     /// }
     /// assert_eq!(xVariant.sum(), 2_000.0);
     /// ```
+    #[inline(always)]
     fn add(&mut self, value: f64) {
         match self {
             Self::Small(xsum_small) => xsum_small.add(value),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use xsum::{Xsum, XsumAuto, XsumExt, XsumLarge, XsumSmall};
+use xsum::{Xsum, XsumAuto, XsumExt, XsumLarge, XsumSmall, XsumVariant};
 
 fn is_valid(actual: f64, expected: f64) -> bool {
     // check NaN, 0, -0, infinity, -infinity, finite values
@@ -19,15 +19,58 @@ pub(crate) fn same_value(vec: &[f64], expected: f64) {
     xsumsmall.add_list(vec);
     assert!(is_valid(xsumsmall.sum(), expected));
 
+    xsumsmall.clear();
+    assert!(is_valid(xsumsmall.sum(), -0.0));
+
+    for &val in vec {
+        xsumsmall.add(val);
+    }
+    assert!(is_valid(xsumsmall.sum(), expected));
+
     // XsumLarge
     let mut xsumlarge = XsumLarge::new();
     xsumlarge.add_list(vec);
+    assert!(is_valid(xsumlarge.sum(), expected));
+
+    xsumlarge.clear();
+    assert!(is_valid(xsumlarge.sum(), -0.0));
+
+    for &val in vec {
+        xsumlarge.add(val);
+    }
     assert!(is_valid(xsumlarge.sum(), expected));
 
     // XsumAuto
     let mut xsumauto = XsumAuto::new();
     xsumauto.add_list(vec);
     assert!(is_valid(xsumauto.sum(), expected));
+
+    xsumauto.clear();
+    assert!(is_valid(xsumauto.sum(), -0.0));
+
+    for &val in vec {
+        xsumauto.add(val);
+    }
+    assert!(is_valid(xsumauto.sum(), expected));
+
+    // XsumVariant
+    let mut xsumvariant = if vec.len() <= 3 {
+        XsumVariant::Small(XsumSmall::new())
+    } else if vec.len() <= 5 {
+        XsumVariant::Large(XsumLarge::new())
+    } else {
+        XsumVariant::Auto(XsumAuto::new())
+    };
+    xsumvariant.add_list(vec);
+    assert!(is_valid(xsumvariant.sum(), expected));
+
+    xsumvariant.clear();
+    assert!(is_valid(xsumvariant.sum(), -0.0));
+
+    for &val in vec {
+        xsumvariant.add(val);
+    }
+    assert!(is_valid(xsumvariant.sum(), expected));
 
     // XsumExt
     assert!(is_valid(vec.xsum(), expected));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -213,3 +213,16 @@ fn zeros() {
     same_value(&[-0.0, 0.0], 0.0);
     same_value(&[0.0], 0.0);
 }
+
+#[test]
+fn large_sized_array() {
+    same_value(&[0.1; 1_000], 100.0);
+    same_value(&[0.1; 2_000], 200.0);
+    same_value(&[1e308; 1_000], INFINITY);
+    same_value(&[-1e308; 1_000], -INFINITY);
+    same_value(&[1e-308; 2_000], 1.9999999999999997e-305);
+    same_value(&[NaN; 2_000], NaN);
+    same_value(&[INFINITY; 2_000], INFINITY);
+    same_value(&[-INFINITY; 2_000], -INFINITY);
+    same_value(&[-0.0; 2_000], -0.0);
+}


### PR DESCRIPTION
- Improve doc
- Add test cases for large-sized array input
- Test against `add()`, `clear()`, and `XsumVariant`
- Add `#[inline(always)]` to `add()` of `XsumVarian`
