### PR TITLE
fix: incorrect rounding for extreme negative values

### DIFF
--- a/src/xsum_small.rs
+++ b/src/xsum_small.rs
@@ -288,23 +288,25 @@ impl Xsum for XsumSmall {
             if (ivalue & 3) == 3 {
                 // extra bits are 11
                 should_round_away_from_zero = true;
-            }
-
-            if lower == 0 {
-                // see if any lower bits are non-zero
-                while j > 0 {
-                    j -= 1;
-                    if self.m_sacc.m_chunk[j as usize] != 0 {
-                        lower = 1;
-                        break;
+            } else if (ivalue & 3) >= 2 && (ivalue & 4) != 0 {
+                // extra bits are 10, low bit is 1 (odd) — check lower bits
+                if lower == 0 {
+                    // see if any lower bits are non-zero
+                    while j > 0 {
+                        j -= 1;
+                        if self.m_sacc.m_chunk[j as usize] != 0 {
+                            lower = 1;
+                            break;
+                        }
                     }
                 }
+                if lower == 0 {
+                    // low bit 1 (odd), extra bits are 10, lower bits all zero
+                    should_round_away_from_zero = true;
+                }
             }
-
-            if lower == 0 {
-                // low bit 1 (odd), extra bits are 10, lower bits are all 0
-                should_round_away_from_zero = true;
-            }
+            // extra bits 00 or 01: no rounding needed
+            // extra bits 10 with even low bit: no rounding needed (round to even)
         }
 
         if should_round_away_from_zero {

--- a/src/xsum_small.rs
+++ b/src/xsum_small.rs
@@ -288,8 +288,17 @@ impl Xsum for XsumSmall {
             if (ivalue & 3) == 3 {
                 // extra bits are 11
                 should_round_away_from_zero = true;
-            } else if (ivalue & 3) >= 2 && (ivalue & 4) != 0 {
-                // extra bits are 10, low bit is 1 (odd) — check lower bits
+            } else if (ivalue & 3) <= 1 {
+                // extra bits are 00 or 01
+                // TODO: this is not required,
+                // but removing the branch would change the logic
+                should_round_away_from_zero = false;
+            } else if (ivalue & 4) == 0 {
+                // low bit is 0 (even), extra bits are 10
+                // TODO: this is not required,
+                // but removing the branch would change the logic
+                should_round_away_from_zero = false;
+            } else {
                 if lower == 0 {
                     // see if any lower bits are non-zero
                     while j > 0 {
@@ -301,12 +310,10 @@ impl Xsum for XsumSmall {
                     }
                 }
                 if lower == 0 {
-                    // low bit 1 (odd), extra bits are 10, lower bits all zero
+                    // low bit 1 (odd), extra bits are 10, lower bits are all 0
                     should_round_away_from_zero = true;
                 }
             }
-            // extra bits 00 or 01: no rounding needed
-            // extra bits 10 with even low bit: no rounding needed (round to even)
         }
 
         if should_round_away_from_zero {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -187,6 +187,8 @@ fn complex() {
         -1.797_693_134_862_315_7e308,
     );
     same_value(&[8.98846567431158e+307, 8.98846567431158e+307], INFINITY);
+    same_value(&[f64::MIN], f64::MIN);
+    same_value(&[f64::MIN, 0.0], f64::MIN);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -188,7 +188,13 @@ fn complex() {
     );
     same_value(&[8.98846567431158e+307, 8.98846567431158e+307], INFINITY);
     same_value(&[f64::MIN], f64::MIN);
+    same_value(&[-f64::MIN], -f64::MIN);
     same_value(&[f64::MIN, 0.0], f64::MIN);
+    same_value(&[f64::MIN, -0.0], f64::MIN);
+    same_value(&[f64::MAX], f64::MAX);
+    same_value(&[-f64::MAX, 0.0], -f64::MAX);
+    same_value(&[f64::MAX, 0.0], f64::MAX);
+    same_value(&[f64::MAX, -0.0], f64::MAX);
 }
 
 #[test]
@@ -205,6 +211,14 @@ fn nan_infinity() {
     same_value(&[INFINITY, INFINITY], INFINITY);
     same_value(&[-INFINITY], -INFINITY);
     same_value(&[-INFINITY, -INFINITY], -INFINITY);
+
+    same_value(&[f64::MIN, INFINITY], INFINITY);
+    same_value(&[f64::MIN, -INFINITY], -INFINITY);
+    same_value(&[f64::MIN, NaN], NaN);
+
+    same_value(&[f64::MAX, INFINITY], INFINITY);
+    same_value(&[f64::MAX, -INFINITY], -INFINITY);
+    same_value(&[f64::MAX, NaN], NaN);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`sum([f64::MIN])` returns `-inf` instead of `f64::MIN`. The negative rounding path in `xsum_small.rs` is missing two early-exit conditions present in the original C implementation by Radford Neal.

The extra bits 00/01 case and the even-low-bit with extra bits 10 case should skip rounding, but the code falls through unconditionally to round-away-from-zero when `lower == 0`. For `f64::MIN` (exponent 2046), this causes a spurious exponent increment from 2046 to 2047, which triggers the infinity check and returns `-inf`. This violates Math.sumPrecise conformance because Math.sumPrecise([-Number.MAX_VALUE]) should return -Number.MAX_VALUE, not -Infinity.

Fixes #15

## Changes

- Add the two missing guards to match the reference C implementation ([xsum.c](https://gitlab.com/radfordneal/xsum/-/raw/master/xsum.c))
- Add regression tests for `sum([f64::MIN])` and `sum([f64::MIN, 0.0])`

## Test plan

- [x] `cargo test` passes (all 32 tests)
- [x] Verified `sum([f64::MIN])` now returns `f64::MIN` instead of `-inf`